### PR TITLE
use openweathermap api instead

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,17 @@
+const queryURL = "api.openweathermap.org/data/2.5/weather?q=" + City + "usa&APPID=ff175c5d4fbe21dbdd37b7f1c9b145c0"
+
+$.ajax({
+    url: queryURL,
+    method: "GET"
+})
+
+.then(function(response){
+    console.log(queryURL);
+    console.log(response);
+
+    $(".city").html("<h1>" + response.name + " Weather Details</h1>");
+    $(".wind").text("Wind Speed: " + response.wind.speed);
+    $(".humidity").text("Humidity: " + response.main.humidity);
+    $(".temp").text("Temperature (F) " + response.main.temp);
+
+});


### PR DESCRIPTION
This will replace the "aaronweather" branch I made a pull request for earlier today.  The API used in "aaronweather" is called MetaWeather Beta, and it is very very beta, and the documentation is difficult to read, so I think the API in this branch, openweatherapi, is better because it's not beta, and it's the same API that we used in one of our class exercises (week 6).  I made my own account through openweatherapi, and received my own API key which should become active within the next few hours.